### PR TITLE
Center map on Austin, TX

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
     const map = (window.map = new maplibregl.Map({
         container: 'map',
         zoom: 12,
-        center: [11.39085, 47.27574],
-        pitch: 70,
+        center: [-97.7431, 30.2672],
+        pitch: 60,
         hash: true,
         style: {
             version: 8,


### PR DESCRIPTION
## Summary
- focus map on Austin by setting center to [-97.7431, 30.2672]
- adjust pitch for a better city view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b718f29f64832a9448adef583f1800