### PR TITLE
Use Terrarium DEM tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,13 +34,17 @@
                 // Use a different source for terrain and hillshade layers, to improve render quality
                 terrainSource: {
                     type: 'raster-dem',
-                    url: 'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
-                    tileSize: 256
+                    tiles: ['https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png'],
+                    tileSize: 256,
+                    maxzoom: 15,
+                    encoding: 'terrarium'
                 },
                 hillshadeSource: {
                     type: 'raster-dem',
-                    url: 'https://demotiles.maplibre.org/terrain-tiles/tiles.json',
-                    tileSize: 256
+                    tiles: ['https://elevation-tiles-prod.s3.amazonaws.com/terrarium/{z}/{x}/{y}.png'],
+                    tileSize: 256,
+                    maxzoom: 15,
+                    encoding: 'terrarium'
                 }
             },
             layers: [


### PR DESCRIPTION
## Summary
- replace demo terrain tiles with open Terrarium DEM tiles
- configure tile array, encoding, and max zoom for terrain and hillshade sources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b71cae65d4832a83c16ad557fc3036