### PR TITLE
Swap map and media between sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,24 +8,39 @@
     <link rel='stylesheet' href='https://unpkg.com/maplibre-gl@5.7.0/dist/maplibre-gl.css' />
     <script src='https://unpkg.com/maplibre-gl@5.7.0/dist/maplibre-gl.js'></script>
     <style>
-        body { margin: 0; padding: 0; }
-        html, body, #map { height: 100%; }
+        body { margin: 0; padding: 0; font-family: sans-serif; }
+        section { padding: 20px; }
+        .map-container { position: relative; height: 500px; }
+        #map { height: 100%; }
         #exaggeration-control {
             position: absolute;
             top: 10px;
             left: 10px;
             background: rgba(255, 255, 255, 0.8);
             padding: 10px;
-            font-family: sans-serif;
             z-index: 1;
         }
+        .video-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; }
+        .video-container iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
     </style>
 </head>
 <body>
-<div id="map"></div>
-<div id="exaggeration-control">
-  <label>Exaggeration: <input id="exaggeration" type="range" min="1" max="10" step="0.1" value="3" /></label>
-</div>
+<section id="about">
+    <h2>About</h2>
+    <div class="video-container">
+        <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E" title="YouTube video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+    </div>
+</section>
+
+<section id="services">
+    <h2>Services</h2>
+    <div class="map-container">
+        <div id="map"></div>
+        <div id="exaggeration-control">
+          <label>Exaggeration: <input id="exaggeration" type="range" min="1" max="10" step="0.1" value="3" /></label>
+        </div>
+    </div>
+</section>
 <script>
     const map = (window.map = new maplibregl.Map({
         container: 'map',


### PR DESCRIPTION
## Summary
- Embed a YouTube video in the About section
- Move the interactive map and terrain slider to the Services section and remove the old image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7457da33c832a952a5682b2a487fb