### PR TITLE
Ensure video and map are in separate sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,22 +20,18 @@
             padding: 10px;
             z-index: 1;
         }
-        .video-container { position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%; }
-        .video-container iframe { position: absolute; top: 0; left: 0; width: 100%; height: 100%; }
     </style>
 </head>
 <body>
 <section id="about">
     <h2>About</h2>
-    <div class="video-container">
-        <iframe src="https://www.youtube.com/embed/C9W6zWNgO4E" title="YouTube video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-    </div>
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/C9W6zWNgO4E" title="3D Terrain demonstration" style="border:0;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </section>
 
 <section id="services">
     <h2>Services</h2>
     <div class="map-container">
-        <div id="map"></div>
+        <div id="map" aria-label="Interactive 3D terrain map"></div>
         <div id="exaggeration-control">
           <label>Exaggeration: <input id="exaggeration" type="range" min="1" max="10" step="0.1" value="3" /></label>
         </div>


### PR DESCRIPTION
## Summary
- Embed About section video with a simple borderless iframe and descriptive title
- Label Services map for accessibility and remove old video-wrapper CSS

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b74f0578f8832a8c7dd46fc27b6bff