### PR TITLE
Remove About video iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,6 @@
     </style>
 </head>
 <body>
-<section id="about">
-    <h2>About</h2>
-    <iframe width="560" height="315" src="https://www.youtube.com/embed/C9W6zWNgO4E" title="3D Terrain demonstration" style="border:0;" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-</section>
-
 <section id="services">
     <h2>Services</h2>
     <div class="map-container">


### PR DESCRIPTION
## Summary
- remove outdated About video section from homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b75a70bd90832a866f5761642a5676